### PR TITLE
fix #561: ignore option isEmpty checking

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -462,8 +462,6 @@ export default {
      */
     getOptionLabel (option) {
       /* istanbul ignore else */
-      if (isEmpty(option)) return ''
-      /* istanbul ignore else */
       if (option.isTag) return option.label
       /* istanbul ignore else */
       if (option.$isLabel) return option.$groupLabel


### PR DESCRIPTION
It should fix [#561](https://github.com/monterail/vue-multiselect/issues/561). 

`option` will be double checked in this function:
```
getOptionLabel (option) {
    /* istanbul ignore else */
    if (isEmpty(option)) return ''
    /* istanbul ignore else */
    if (option.isTag) return option.label
    /* istanbul ignore else */
    if (option.$isLabel) return option.$groupLabel

    let label = this.customLabel(option, this.label)
    /* istanbul ignore else */
    if (isEmpty(label)) return ''
    return label
},
```

If you dont't use `custom-label`, the default function will handle the empty value. So there is no need for type checking and returning `''` at the entry of this function.