### PR TITLE
Increased font-size of input to sensible minimum.

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -331,7 +331,7 @@ fieldset[disabled] .multiselect {
 .multiselect__input,
 .multiselect__single {
   font-family: inherit;
-  font-size: 14px;
+  font-size: 16px;
   touch-action: manipulation;
 }
 


### PR DESCRIPTION
The input element in Vue Multiselect currently has a font-size of 14px. This small font-size causes mobile devices to zoom in when the input receives focus. To avoid this zoom, inputs should have a minimum font-size of 16px.