### PR TITLE
Different color for .multiselect__single and .multiselect__input if value is selected.

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -399,7 +399,7 @@ fieldset[disabled] .multiselect {
 }
 
 .multiselect__single.selected, .multiselect__input {
-   color: red;
+   color: black;
  }
 
 .multiselect__tag ~ .multiselect__input,

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -398,8 +398,8 @@ fieldset[disabled] .multiselect {
   vertical-align: top;
 }
 
-.multiselect__single .selected, .multiselect__input {
-   color: black;
+.multiselect__single.selected, .multiselect__input {
+   color: red;
  }
 
 .multiselect__tag ~ .multiselect__input,

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -54,6 +54,7 @@
         <span
           v-if="!searchable"
           class="multiselect__single"
+          :class="{ selected: internalValue.length }"
           @mousedown.prevent="toggle"
           v-text="currentOptionLabel">
         </span>
@@ -396,6 +397,10 @@ fieldset[disabled] .multiselect {
   margin-bottom: 8px;
   vertical-align: top;
 }
+
+.multiselect__single .selected, .multiselect__input {
+   color: black;
+ }
 
 .multiselect__tag ~ .multiselect__input,
 .multiselect__tag ~ .multiselect__single {


### PR DESCRIPTION
I think it should be clear to user, when value is selected on widget. 
before:
![before](https://user-images.githubusercontent.com/3405082/32817468-8d70e410-ca09-11e7-87f1-30cf5c778883.png)
after: 
![after](https://user-images.githubusercontent.com/3405082/32817471-96ef37bc-ca09-11e7-97c7-317d3b1c2c3b.png)


I am not 100% sure, if `.selected` class should be used. I will rename this if needed.