### PR TITLE
add a bool prop, which when true, will disable tag deselection (making it work like a regular single select dropdown)

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -504,11 +504,11 @@ export default {
       } else {
         const isSelected = this.isSelected(option)
         if (isSelected) {
-           if (this.disableTagDeselection) {
+			if (this.disableTagDeselection) {
             this.deactivate()
           } else {
-			if (key !== 'Tab') this.removeElement(option)
-			return
+			  if (key !== 'Tab') this.removeElement(option)
+			  return
           }
         } else if (this.multiple) {
           this.internalValue.push(option)

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -171,6 +171,15 @@ export default {
       type: Boolean,
       default: true
     },
+	/**
+     * When the same tag is selected as was selected previously, the value will not be cleared
+     * @default false
+     * @type {Boolean}
+     */
+    disableTagDeselection: {
+      type: Boolean,
+      default: false
+    },
     /**
      * Reset this.internalValue, this.search after this.internalValue changes.
      * Useful if want to create a stateless dropdown.
@@ -495,8 +504,12 @@ export default {
       } else {
         const isSelected = this.isSelected(option)
         if (isSelected) {
-          if (key !== 'Tab') this.removeElement(option)
-          return
+           if (this.disableTagDeselection) {
+            this.deactivate()
+          } else {
+			if (key !== 'Tab') this.removeElement(option)
+			return
+          }
         } else if (this.multiple) {
           this.internalValue.push(option)
         } else {


### PR DESCRIPTION
add a bool prop, which when true, will disable tag deselection (making it work like a regular single select dropdown).

If this prop is true, then the code skips removing the element, and closes the dropdown.