### PR TITLE
Has values class

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -271,7 +271,7 @@
         }
       },
       hasValues () {
-        return this.value && this.value.length > 0;
+        return this.value && this.value.length > 0
       }
     }
   }

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :tabindex="searchable ? -1 : tabindex"
-    :class="{ 'multiselect--active': isOpen, 'multiselect--disabled': disabled, 'multiselect--above': isAbove }"
+    :class="{ 'multiselect--active': isOpen, 'multiselect--disabled': disabled, 'multiselect--above': isAbove, 'multiselect--has-values': hasValues }"
     @focus="activate()"
     @blur="searchable ? false : deactivate()"
     @keydown.self.down.prevent="pointerForward()"
@@ -251,7 +251,7 @@
           : ''
       },
       inputStyle () {
-        if (this.multiple && this.value && this.value.length) {
+        if (this.multiple && this.hasValues) {
           // Hide input by setting the width to 0 allowing it to receive focus
           return this.isOpen ? { 'width': 'auto' } : { 'width': '0', 'position': 'absolute' }
         }
@@ -269,6 +269,9 @@
         } else {
           return this.prefferedOpenDirection === 'above'
         }
+      },
+      hasValues () {
+        return this.value && this.value.length > 0;
       }
     }
   }


### PR DESCRIPTION
**tldr;** This PR adds a `.multiselect--has-values` class to the main element when there is one or more items selected.

## Reason
My placeholder is pretty long, so I need to set a width for the input.
The width for the input is currently controlled in the `inputStyle()` method here https://github.com/shentao/vue-multiselect/blob/master/src/Multiselect.vue#L256.

By adding the `.multiselect-has-values` class, I am able to mimic the default behaviour (showing the placeholder when there are no values, or the select is active; hiding it in other cases.

I'm using this snippet of sass
```scss
.multiselect,
.multiselect.multiselect--active.multiselect--has-values {
  .multiselect__input {
    width: 300px !important;
  }
}
.multiselect.multiselect--has-values {
  .multiselect__input {
    width: 0 !important;
  }
}
```

Curious to hear if there's a better way to do this.