### PR TITLE
Use property for placeholder width

### DIFF
--- a/documentation/partials/api/_props.pug
+++ b/documentation/partials/api/_props.pug
@@ -84,6 +84,12 @@ h2.typo__h2#sub-props(data-section) Props
             kbd placeholder
             |  attribute on a &lt;select&gt; input.
         tr.table__tr
+          td.table__td: strong placeholderWidth
+          td.table__td String
+          td.table__td: kbd 'auto'
+          td.table__td
+            | Set a custom width for the placeholder.
+        tr.table__tr
           td.table__td: strong allowEmpty
           td.table__td Boolean
           td.table__td: kbd true

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -165,6 +165,15 @@
         default: true
       },
       /**
+       * The width for the placeholder
+       * @default auto
+       * @type {String}
+      */
+      placeholderWidth: {
+        type: String,
+        default: 'auto'
+      },
+      /**
        * Limit the display of selected options. The rest will be hidden within the limitText string.
        * @default 99999
        * @type {Integer}
@@ -251,9 +260,12 @@
           : ''
       },
       inputStyle () {
-        if (this.multiple && this.value && this.value.length) {
+        if (this.multiple) {
+          if (this.isOpen) {
+            return { 'width': this.placeholderWidth }
+          }
           // Hide input by setting the width to 0 allowing it to receive focus
-          return this.isOpen ? { 'width': 'auto' } : { 'width': '0', 'position': 'absolute' }
+          return this.hasValues ? { 'width': '0', 'position': 'absolute' } : { 'width': this.placeholderWidth }
         }
       },
       contentStyle () {
@@ -269,6 +281,9 @@
         } else {
           return this.prefferedOpenDirection === 'above'
         }
+      },
+      hasValues () {
+        return this.value && this.value.length
       }
     }
   }


### PR DESCRIPTION
Related to https://github.com/shentao/vue-multiselect/pull/604
## Usecase
When your placeholder exceeds the width of the input element, you can set the `placeholderWidth` property to something like `300px` or some other valid size.

This solution is probably more straightforward then https://github.com/shentao/vue-multiselect/pull/604