### PR TITLE
Adjust pointer position when currently selected option is a label. 

### DIFF
--- a/src/pointerMixin.js
+++ b/src/pointerMixin.js
@@ -94,6 +94,10 @@ export default {
           ? this.filteredOptions.length - 1
           : 0
       }
+
+      if (this.filteredOptions.length > 0 && this.filteredOptions[this.pointer].$isLabel) {
+        this.pointerForward()
+      }
     },
     pointerSet (index) {
       this.pointer = index

--- a/test/unit/specs/Multiselect.spec.js
+++ b/test/unit/specs/Multiselect.spec.js
@@ -1441,6 +1441,34 @@ describe('Multiselect.vue', () => {
       vm.$children[0].pointerAdjust()
       expect(vm.$children[0].pointer).to.equal(2)
     })
+    it('should adjust the pointer to the first non-group-label option after changed from empty', (done) => {
+      const vm = new Vue({
+        render (h) {
+          return h(Multiselect, {
+            props: {
+              value: this.value,
+              options: this.source,
+              label: 'id',
+              trackBy: 'id',
+              multiple: true,
+              groupValues: 'group',
+              groupLabel: 'groupLabel'
+            }
+          })
+        },
+        components: { Multiselect },
+        data: {
+          value: [],
+          source: []
+        }
+      }).$mount()
+
+      vm.source = [{ group: [{ id: '1' }, { id: '2' }], groupLabel: 'A' }]
+      setTimeout(function () {
+        expect(vm.$children[0].pointer).to.equal(1)
+        done()
+      }, 0)
+    })
   })
 
   describe('#watch:value', () => {


### PR DESCRIPTION
This can happen when multiselect was opened as empty and group was added at runtime.

Test reproducing that case is included.

Fiddle to demonstrate the issue:
https://jsfiddle.net/jqofkzxc/282/