### PR TITLE
Single select custom html label

### DIFF
--- a/documentation/partials/api/_slots.pug
+++ b/documentation/partials/api/_slots.pug
@@ -41,3 +41,7 @@ h2.typo__h2#sub-slots(data-section) Slots
             | Props
             ul
               li <code>toggle: Function</code> – toggles the dropdown.
+        tr.table__tr
+          td.table__td: strong singleLabel
+          td.table__td
+            | Slot for custom label template for single select

--- a/documentation/partials/examples/SingleSelectCustomLabel.vue
+++ b/documentation/partials/examples/SingleSelectCustomLabel.vue
@@ -1,0 +1,55 @@
+<template lang="pug">
+div
+  label.typo__label Single select / dropdown
+  multiselect(
+    v-model="value",
+    deselect-label="Can't remove this value",
+    track-by="img",
+    label="img",
+    placeholder="Select one",
+    :options="options",
+    :searchable="false",
+    :allow-empty="false"
+  )
+    template(slot="singleLabel", slot-scope="props")
+      img.label-image(:src="props.currentOptionLabel", alt="No Man’s Sky")
+      span.label-text
+        | this is
+        | html
+  pre.language-json
+    code.
+      {{ value  }}
+
+</template>
+
+<script>
+import Multiselect from 'vue-multiselect'
+
+export default {
+  components: {
+    Multiselect
+  },
+  data () {
+    return {
+      value: { title: 'Explorer', desc: 'Discovering new species!', img: 'static/posters/creatures.png' },
+      options: [
+        { title: 'Space Pirate', desc: 'More space battles!', img: 'static/posters/fleet.png' },
+        { title: 'Merchant', desc: 'PROFIT!', img: 'static/posters/trading_post.png' },
+        { title: 'Explorer', desc: 'Discovering new species!', img: 'static/posters/creatures.png' },
+        { title: 'Miner', desc: 'We need to go deeper!', img: 'static/posters/resource_lab.png' }
+      ]
+    }
+  }
+}
+</script>
+
+<style lang="css">
+.label-image {
+  max-height: 50px;
+}
+.label-text {
+  padding: 1px;
+  color: #41B883;
+  margin: 10px;
+}
+</style>

--- a/documentation/partials/examples/_examples.pug
+++ b/documentation/partials/examples/_examples.pug
@@ -31,6 +31,17 @@
 
       `custom-label` accepts a function with the `option` object as the first param. It should return a string which is then used to display a custom label.
     +example('SingleSelectSearch')
+  +subsection('Select with custom label')
+    :markdown-it
+      For the moment this feature requires `searchable` to be disabled.
+
+      It is useful to use custom labels with custom options from [custom options template](#sub-custom-option-template). For example a courtry dropdown that allows showing flag images only in the label after selection.
+
+      `custom-label` can be used instead of `label` as well.
+
+      #### Configuration flags:
+       - `currentOptionLabel` – The label value from the selected item.
+    +example('SingleSelectCustomLabel')
   +subsection('Multiple select')
     :markdown-it
       To allow multiple selections pass the `:multiple="true"` prop.

--- a/documentation/partials/examples/index.js
+++ b/documentation/partials/examples/index.js
@@ -1,6 +1,7 @@
 import SingleSelectPrimitive from './SingleSelectPrimitive'
 import SingleSelectObject from './SingleSelectObject'
 import SingleSelectSearch from './SingleSelectSearch'
+import SingleSelectCustomLabel from './SingleSelectCustomLabel'
 import MultiSelect from './MultiSelect'
 import AjaxSearch from './AjaxSearch'
 import Tagging from './Tagging'
@@ -14,6 +15,7 @@ export {
   SingleSelectPrimitive,
   SingleSelectObject,
   SingleSelectSearch,
+  SingleSelectCustomLabel,
   MultiSelect,
   AjaxSearch,
   Tagging,

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -54,8 +54,10 @@
         <span
           v-if="!searchable"
           class="multiselect__single"
-          @mousedown.prevent="toggle"
-          v-text="currentOptionLabel">
+          @mousedown.prevent="toggle">
+          <slot name="singleLabel" :currentOptionLabel="currentOptionLabel">
+            <template>{{currentOptionLabel}}</template>
+          </slot>
         </span>
       </div>
       <transition name="multiselect">


### PR DESCRIPTION
Add named scope for label, and add an example in the docs

This pull request is related to https://github.com/shentao/vue-multiselect/issues/377 and  https://github.com/shentao/vue-multiselect/issues/371 and https://github.com/shentao/vue-multiselect/issues/82
I am not sure what naming methods to use so feel free to rename and edit whatever you see fit