### PR TITLE
Set padding to '0' when item is selected to prevent small input box from appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-multiselect",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -253,7 +253,7 @@
       inputStyle () {
         if (this.multiple && this.value && this.value.length) {
           // Hide input by setting the width to 0 allowing it to receive focus
-          return this.isOpen ? { 'width': 'auto' } : { 'width': '0', 'position': 'absolute' }
+          return this.isOpen ? { 'width': 'auto' } : { 'width': '0', 'position': 'absolute', 'padding': '0' }
         }
       },
       contentStyle () {


### PR DESCRIPTION
I noticed that due to the padding on the input element, when an item is selected and the "width" is set to 0, there is still padding an a small input box would appear below the multi-select.