### PR TITLE
Fix for removing correct selected Items if MultiSelect array allows for duplicates

### DIFF
--- a/lib/multiselectMixin.js
+++ b/lib/multiselectMixin.js
@@ -14,6 +14,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+function createGuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = Math.random() * 16 | 0;
+    var v = c === 'x' ? r : r & 0x3 | 0x8;
+    return v.toString(16);
+  });
+}
+
 function isEmpty(opt) {
   if (opt === 0) return false;
   if (Array.isArray(opt) && opt.length === 0) return true;
@@ -326,6 +334,10 @@ exports.default = {
       return label;
     },
     select: function select(option, key) {
+      if ((typeof option === 'undefined' ? 'undefined' : _typeof(option)) === 'object') {
+        option.__internalId = createGuid();
+      }
+
       if (this.blockKeys.indexOf(key) !== -1 || this.disabled || option.$isLabel || option.$isDisabled) return;
 
       if (this.max && this.multiple && this.internalValue.length === this.max) return;
@@ -365,7 +377,17 @@ exports.default = {
 
       var index = (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === 'object' ? this.valueKeys.indexOf(option[this.trackBy]) : this.valueKeys.indexOf(option);
 
-      this.internalValue.splice(index, 1);
+      var newIndex = 0;
+      if ((typeof option === 'undefined' ? 'undefined' : _typeof(option)) === 'object') {
+        newIndex = index === -1 ? this.internalValue.indexOf(this.internalValue.find(function (el) {
+          return el.__internalId === option.__internalId;
+        })) : index;
+      } else {
+        newIndex = index === -1 ? this.internalValue.indexOf(this.internalValue.find(function (el) {
+          return el === option;
+        })) : index;
+      }
+      this.internalValue.splice(newIndex, 1);
       this.$emit('input', this.getValue(), this.id);
       this.$emit('remove', (0, _utils2.default)(option), this.id);
 

--- a/lib/pointerMixin.js
+++ b/lib/pointerMixin.js
@@ -91,6 +91,10 @@ exports.default = {
       if (this.pointer >= this.filteredOptions.length - 1) {
         this.pointer = this.filteredOptions.length ? this.filteredOptions.length - 1 : 0;
       }
+
+      if (this.filteredOptions.length > 0 && this.filteredOptions[this.pointer].$isLabel) {
+        this.pointerForward();
+      }
     },
     pointerSet: function pointerSet(index) {
       this.pointer = index;

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -1,5 +1,13 @@
 import deepClone from './utils'
 
+function createGuid () {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = Math.random() * 16 | 0
+    var v = c === 'x' ? r : (r & 0x3 | 0x8)
+    return v.toString(16)
+  })
+}
+
 function isEmpty (opt) {
   if (opt === 0) return false
   if (Array.isArray(opt) && opt.length === 0) return true
@@ -482,6 +490,9 @@ export default {
      * @param  {Boolean} block removing
      */
     select (option, key) {
+      if (typeof option === 'object') {
+        option.__internalId = createGuid()
+      }
       /* istanbul ignore else */
       if (this.blockKeys.indexOf(key) !== -1 || this.disabled || option.$isLabel || option.$isDisabled) return
       /* istanbul ignore else */
@@ -532,7 +543,13 @@ export default {
         ? this.valueKeys.indexOf(option[this.trackBy])
         : this.valueKeys.indexOf(option)
 
-      this.internalValue.splice(index, 1)
+      var newIndex = 0
+      if (typeof option === 'object') {
+        newIndex = index === -1 ? this.internalValue.indexOf(this.internalValue.find((el) => el.__internalId === option.__internalId)) : index
+      } else {
+        newIndex = index === -1 ? this.internalValue.indexOf(this.internalValue.find((el) => el === option)) : index
+      }
+      this.internalValue.splice(newIndex, 1)
       this.$emit('input', this.getValue(), this.id)
       this.$emit('remove', deepClone(option), this.id)
 


### PR DESCRIPTION
See https://github.com/shentao/vue-multiselect/pull/614 for details. Credit to @Jtorrecilla for this fix. 

This is a branch with the code from PR- https://github.com/shentao/vue-multiselect/pull/614 that fixes issue https://github.com/shentao/vue-multiselect/issues/282, that hopefully can be easily merged in the next release. 

Happy to make any changes needed / requested. 