### PR TITLE
Possibility to change or disable auto* properties

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -277,19 +277,19 @@ export default {
       default: true
     },
     autocomplete: {
-      type: 'String',
+      type: String,
       default: 'off'
     },
     autocorrect: {
-      type: 'String',
+      type: String,
       default: 'off'
     },
     autocapitalize: {
-      type: 'String',
+      type: String,
       default: 'off'
     },
     spellcheck: {
-      type: 'String',
+      type: String,
       default: 'false'
     },
     tabindex: {


### PR DESCRIPTION
In my project multiselect is used for searching names. But Safari browser often corrects the name to a different word and it leads a lot of troubles.