### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ npm-debug.log
 selenium-debug.log
 tests/unit/coverage
 tests/e2e/reports
-.editorconfig
-.tern-project


### PR DESCRIPTION
Both, the .tern-project and the .editorconfig files have valid reasons to be committed to the repository and should thus not be in the .gitignore list.