### PR TITLE
Disable autocomplete in Chrome

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -48,7 +48,7 @@
           :name="name"
           :id="id"
           type="text"
-          autocomplete="off"
+          autocomplete="nope"
           :placeholder="placeholder"
           :style="inputStyle"
           :value="search"


### PR DESCRIPTION
This fixes #728 and is a duplicate of #769. This is important as Chrome will tend to autocomplete any input it finds.