### PR TITLE
consider `$isDisabled` before removing selected

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -599,7 +599,7 @@ export default {
       /* istanbul ignore else */
       if (this.disabled) return
       /* istanbul ignore else */
-      if (this.option.$isDisabled) return
+      if (option.$isDisabled) return
       /* istanbul ignore else */
       if (!this.allowEmpty && this.internalValue.length <= 1) {
         this.deactivate()

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -599,6 +599,8 @@ export default {
       /* istanbul ignore else */
       if (this.disabled) return
       /* istanbul ignore else */
+      if (this.option.$isDisabled) return
+      /* istanbul ignore else */
       if (!this.allowEmpty && this.internalValue.length <= 1) {
         this.deactivate()
         return


### PR DESCRIPTION
If a `$isDisabled: true` option is preselected, it should not be deletable.