### PR TITLE
Fix cut off placeholders

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -326,7 +326,7 @@ export default {
       ) {
         // Hide input by setting the width to 0 allowing it to receive focus
         return this.isOpen
-          ? { width: 'auto' }
+          ? { width: '100%' }
           : { width: '0', position: 'absolute', padding: '0' }
       }
     },


### PR DESCRIPTION
Fixes #886 

Longer placeholders are being cut off when the options are opened.

This appears to be caused by the input element receiving a style of width: auto when open. Changing this to width: 100% when open allows the placeholder to fill the remaining space in the multiselect.

I manually tested this by adding long placeholders and didn't find any problems resulting from this change.