### PR TITLE
fix #945

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -560,7 +560,7 @@ export default {
 
         this.$emit('input', newValue, this.id)
       } else {
-        const optionsToAdd = group[this.groupValues].filter(not(this.isOptionDisabled || this.isSelected))
+        const optionsToAdd = group[this.groupValues].filter(not(this.isOptionDisabled && this.isSelected))
 
         this.$emit('select', optionsToAdd, this.id)
         this.$emit(


### PR DESCRIPTION
before if the option wasn't disabled, but was selected it wouldn't get filtered out of the optionsToAdd. Now it will get filtered out if it's either selected or disabled.

#945 