### PR TITLE
Let npm build the package when installed from source / github master

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "node build/dev-server.js",
     "bundle:dist": "rm -rf dist && webpack --config build/webpack.bundle.conf.js",
     "bundle": "node build/bundle.js",
+    "prepare": "npm run bundle",
     "docs": "rm -rf docs && mkdir docs && node build/build.js",
     "unit": "vue-cli-service test:unit --watch",
     "finish": "npm run lint && npm test && npm run bundle"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "node build/dev-server.js",
     "bundle:dist": "rm -rf dist && webpack --config build/webpack.bundle.conf.js",
     "bundle": "node build/bundle.js",
-    "prepare": "npm run bundle",
+    "prepare": "npm run bundle:dist",
     "docs": "rm -rf docs && mkdir docs && node build/build.js",
     "unit": "vue-cli-service test:unit --watch",
     "finish": "npm run lint && npm test && npm run bundle"


### PR DESCRIPTION
As [discussed elsewhere](https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/).

Running `npm install shentao/vue-multiselect` will install from the github master branch and build it.