### PR TITLE
removed spellcheck from search field (Issue #991)

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -49,6 +49,7 @@
           :id="id"
           type="text"
           autocomplete="nope"
+          spellcheck="false"
           :placeholder="placeholder"
           :style="inputStyle"
           :value="search"


### PR DESCRIPTION
I removed the spellcheck from the search field as it was requested in Issue [#991](https://github.com/shentao/vue-multiselect/issues/991).