### PR TITLE
Accessibility changes: fix for screen readers not identifying options properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-multiselect",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": false,
   "types": "index.d.ts",
   "scripts": {
@@ -9,7 +9,7 @@
     "dev": "node build/dev-server.js",
     "bundle:dist": "rm -rf dist && webpack --config build/webpack.bundle.conf.js",
     "bundle": "node build/bundle.js",
-    "prepare": "npm run bundle:dist",
+    "prepare": "npm run bundle",
     "docs": "rm -rf docs && mkdir docs && node build/build.js",
     "unit": "vue-cli-service test:unit --watch",
     "finish": "npm run lint && npm test && npm run bundle"

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -8,7 +8,9 @@
     @keydown.self.up.prevent="pointerBackward()"
     @keypress.enter.tab.stop.self="addPointerElement($event)"
     @keyup.esc="deactivate()"
-    class="multiselect">
+    class="multiselect"
+    role="combobox"
+    :aria-owns="'listbox-'+id">
       <slot name="caret" :toggle="toggle">
         <div @mousedown.prevent.stop="toggle()" class="multiselect__select"></div>
       </slot>
@@ -63,6 +65,7 @@
           @keypress.enter.prevent.stop.self="addPointerElement($event)"
           @keydown.delete.stop="removeLastElement()"
           class="multiselect__input"
+          :aria-controls="'listbox-'+id"
         />
         <span
           v-if="isSingleLabelVisible"
@@ -93,7 +96,7 @@
           :style="{ maxHeight: optimizedHeight + 'px' }"
           ref="list"
         >
-          <ul class="multiselect__content" :style="contentStyle">
+          <ul class="multiselect__content" :style="contentStyle" role="listbox" :id="'listbox-'+id">
             <slot name="beforeList"></slot>
             <li v-if="multiple && max === internalValue.length">
               <span class="multiselect__option">
@@ -101,7 +104,11 @@
               </span>
             </li>
             <template v-if="!max || internalValue.length < max">
-              <li class="multiselect__element" v-for="(option, index) of filteredOptions" :key="index">
+              <li class="multiselect__element"
+                v-for="(option, index) of filteredOptions"
+                :key="index"
+                v-bind:id="id + '-' + index"
+                v-bind:role="!(option && (option.$isLabel || option.$isDisabled)) ? 'option' : null">
                 <span
                   v-if="!(option && (option.$isLabel || option.$isDisabled))"
                   :class="optionHighlight(index, option)"


### PR DESCRIPTION
Some accessibility testers found some issues with how vue-multiselect interacts with the JAWS screen reader and the NVDA screen reader, when testing a project I work on. 

When using JAWS, the automatic forms modes that JAWS implements prevents the user from navigating the vue-multiselect. The first time the user hits the down arrow it works fine, but at the same time JAWS automatic forms mode causes JAWS to leave forms mode and any following presses on the down arrow do not function properly. This can be fixed using role="application" on your multiselect, however it brings about the following issue that also occurs in NVDA. See issue #1010.

When using JAWS (with role="application") or when using NVDA, the text of the highlighted option is not read by the screen reader when navigating the vue-multiselect with the arrow keys. See issue #1009.

The changes in my request implement aria-activedescendant on the input element of the vue-multiselect. This attribute allows us to change the active child that has focus, which is picked up by screen readers, meaning that the options of the vue-multiselect are read to users with visual impairments.