### PR TITLE
Added clear button to clear all values (works for single & multiselect)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-multiselect",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": false,
   "types": "index.d.ts",
   "scripts": {
@@ -9,7 +9,7 @@
     "dev": "node build/dev-server.js",
     "bundle:dist": "rm -rf dist && webpack --config build/webpack.bundle.conf.js",
     "bundle": "node build/bundle.js",
-    "prepare": "npm run bundle:dist",
+    "prepare": "npm run bundle",
     "docs": "rm -rf docs && mkdir docs && node build/build.js",
     "unit": "vue-cli-service test:unit --watch",
     "finish": "npm run lint && npm test && npm run bundle"

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -49,6 +49,7 @@
           :id="id"
           type="text"
           autocomplete="nope"
+          spellcheck="false"
           :placeholder="placeholder"
           :style="inputStyle"
           :value="search"

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -12,7 +12,9 @@
       <slot name="caret" :toggle="toggle">
         <div @mousedown.prevent.stop="toggle()" class="multiselect__select"></div>
       </slot>
-      <slot name="clear" :search="search"></slot>
+      <slot name="clear" :search="search">
+        <div v-if="clearAllButton" class="multiselect__clear" @mousedown.prevent="clearValue">❌</div>
+      </slot>
       <div ref="tags" class="multiselect__tags">
         <slot
           name="selection"
@@ -284,12 +286,15 @@ export default {
       default: true
     },
     showNoResults: {
-      type: Boolean,
-      default: true
+
     },
     tabindex: {
       type: Number,
       default: 0
+    },
+    clearAllButton: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -828,5 +833,15 @@ fieldset[disabled] .multiselect {
   to {
     transform: rotate(2turn);
   }
+}
+.multiselect__clear {
+  position: absolute;
+  right: 18px;
+  top: 10px;
+  height: 40px;
+  width: 40px;
+  display: block;
+  cursor: pointer;
+  z-index: 2;
 }
 </style>

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -286,7 +286,8 @@ export default {
       default: true
     },
     showNoResults: {
-
+      type: Boolean,
+      default: true
     },
     tabindex: {
       type: Number,

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -709,6 +709,24 @@ export default {
         this.preferredOpenDirection = 'above'
         this.optimizedHeight = Math.min(spaceAbove - 40, this.maxHeight)
       }
+    },
+    /**
+     * Clears the multiselect value/s
+     */
+    clearValue () {
+      /* istanbul ignore else */
+      if (this.disabled) return
+      /* istanbul ignore else */
+      if (!this.allowEmpty && this.internalValue.length <= 1) {
+        this.deactivate();
+        return
+      }
+      console.log('clear multiselect', this.internalValue);
+      for(let option of this.internalValue) {
+        this.$emit('remove', option, this.id);
+      }
+      /* istanbul ignore else */
+      if (this.closeOnSelect && shouldClose) this.deactivate()
     }
   }
 }


### PR DESCRIPTION
I added a prop `clearAllButton` which adds a ❌ to clear the multiselect value/s. It was asked in those issues:
https://github.com/shentao/vue-multiselect/issues/928 & https://github.com/shentao/vue-multiselect/issues/915. 