### PR TITLE
Fix disable autocomplete in Chrome

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -50,7 +50,7 @@
           :name="name"
           :id="id"
           type="text"
-          autocomplete="nope"
+          autocomplete="off"
           spellcheck="false"
           :placeholder="placeholder"
           :style="inputStyle"


### PR DESCRIPTION
Hey,

Please consider to read the docs below, there is nothing about the current attr value `nope`.

- [Specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) [html.spec.whatwg.org] `ref`
- [MDN Web Docs - autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete) [developer.mozilla.org] `ref` `info`

All accepted values can be seen in the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values).

----

It has been said elsewhere that it doesn't work in two other places:

- https://github.com/shentao/vue-multiselect/pull/922#issuecomment-493219937
- https://github.com/shentao/vue-multiselect/issues/728#issuecomment-513750778