### PR TITLE
removed aria from remove element icon.

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -28,7 +28,7 @@
               <slot name="tag" :option="option" :search="search" :remove="removeElement">
                 <span class="multiselect__tag" :key="index">
                   <span v-text="getOptionLabel(option)"></span>
-                  <i aria-hidden="true" tabindex="1" @keypress.enter.prevent="removeElement(option)"  @mousedown.prevent="removeElement(option)" class="multiselect__tag-icon"></i>
+                  <i tabindex="1" @keypress.enter.prevent="removeElement(option)"  @mousedown.prevent="removeElement(option)" class="multiselect__tag-icon"></i>
                 </span>
               </slot>
             </template>


### PR DESCRIPTION
The close icon on the multiselect has conflicting attributes: aria-hidden="true" and tabindex="1". this means that it is hidden from screen readers, but still focusable. https://act-rules.github.io/rules/6cfa84 see Failed Example 4: Focusable content through tabindex.

#708 

Apologies, i could not get the tests to run on my machine.