### PR TITLE
Make select group respect `closeOnSelect` property

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -571,6 +571,8 @@ export default {
           this.id
         )
       }
+      
+      if (this.closeOnSelect) this.deactivate()
     },
     /**
      * Helper to identify if all values in a group are selected


### PR DESCRIPTION
As of current version, *select group* doesn't respect `closeOnSelect` property.
Proposed simple "fix".