### PR TITLE
Fix no-options condition

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -142,7 +142,7 @@
                 <slot name="noResult" :search="search">No elements found. Consider changing the search query.</slot>
               </span>
             </li>
-            <li v-show="showNoOptions && (options.length === 0 && !search && !loading)">
+            <li v-show="showNoOptions && (filteredOptions.length === 0 && !search && !loading)">
               <span class="multiselect__option">
                 <slot name="noOptions">List is empty.</slot>
               </span>


### PR DESCRIPTION
# Reproduction Steps
```html
<Multiselect
  :multiple="false"
  :show-no-results="true"
  :hide-selected="false"
/>
```

# Observe result
When select all avaiable options, there is a blank space on the list.

![Screen Shot 2020-02-28 at 11 36 47 AM](https://user-images.githubusercontent.com/13447235/75510792-b034f200-5a1e-11ea-9301-2f713b4e4e3e.png)

# Expected result
No space on the list if there is no avaiable options. Or show the custom message if any.