### PR TITLE
Feature - Collapsible Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Probably the most complete *selecting* solution for Vue.js 2.0, without jQuery.
 * Multiple select
 * Tagging
 * Dropdowns
+* Collapsible Groups
 * Filtering
 * Search with suggestions
 * Logic split into mixins
@@ -136,6 +137,21 @@ multiselect(
   placeholder="Pick some",
   label="name",
   track-by="name"
+)
+```
+
+### Collapsible Groups
+``` jade
+multiselect(
+  v-model="multiValue"
+  :options="source"
+  group-values="children"
+  group-label="category"
+  track-by="value"
+  label="name"
+  :group-select="true"
+  :multiple="true"
+  :collapseGroups="true"
 )
 ```
 

--- a/src/HeightTransition.vue
+++ b/src/HeightTransition.vue
@@ -1,0 +1,89 @@
+// Component Template
+<template>
+  <transition-group
+    v-on:appear="appear"
+    v-if="isGroup"
+    v-on:enter="enter"
+    v-on:before-leave="beforeLeave"
+    v-bind:class="false"
+    class="transition-auto-axis"
+  >
+    <slot></slot>
+  </transition-group>
+  <transition
+    v-on:appear="appear"
+    v-else
+    v-on:enter="enter"
+    v-on:before-leave="beforeLeave"
+    v-bind:class="false"
+    class="transition-auto-axis"
+  >
+    <slot></slot>
+  </transition>
+</template>
+
+// Component
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  components: {},
+  props: {
+    axis: {
+      type: String,
+      required: false,
+      default: 'Y'
+    },
+    isGroup: {
+      type: Boolean,
+      required: false,
+      defaut: false
+    }
+  },
+  name: 'transition-auto-axis',
+  data() {
+    return {
+      animationSpeed: 500,
+      animationCheckInterval: null
+    }
+  },
+  methods: {
+    appear(el) {
+      el.style.transition = `height ${this.$data.animationSpeed /
+        1000}s, opacity ${this.$data.animationSpeed /
+        1000}s, margin-bottom ${this.$data.animationSpeed / 1000}s`
+    },
+    enter(el, done) {
+      el.style.height = 'auto'
+      const height = getComputedStyle(el).height
+      el.style.marginBottom = '0'
+
+      el.style.height = '0'
+      setTimeout(() => {
+        el.style.height = height
+      })
+
+      el.style.transition = `height ${this.$data.animationSpeed /
+        1000}s, opacity ${this.$data.animationSpeed /
+        1000}s, margin-bottom ${this.$data.animationSpeed / 1000}s`
+
+      this.$data.animationCheckInterval = setInterval(() => {
+        el.style.height = 'auto'
+        clearInterval(this.$data.animationCheckInterval)
+      }, this.$data.animationSpeed)
+
+      done()
+    },
+    beforeLeave(el) {
+      clearInterval(this.$data.animationCheckInterval)
+
+      const height = getComputedStyle(el).height
+      el.style.height = height
+      setTimeout(() => {
+        el.style.height = '0'
+        el.style.marginBottom = '0'
+      })
+    }
+  }
+})
+</script>

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -142,7 +142,7 @@
                 <span
                   :data-select="groupSelect && selectGroupLabelText"
                   :data-deselect="groupSelect && deselectGroupLabelText"
-                  :class="groupHighlight(index, index, true)"
+                  :class="groupHighlight(index, index, true, !closedAccordions.includes(index) ? 'open' : '')"
                   @mouseenter.self="groupSelect && pointerSet(index)"
                   @mousedown.prevent="selectGroup(index, true)"
                   class="multiselect__option multiselect__accordion">
@@ -880,6 +880,10 @@ fieldset[disabled] .multiselect {
   margin-right: 35px;
 }
 
+.multiselect__accordion:not(.open) .multiselect__accordion-toggle:after{
+  transform: rotate(180deg);
+}
+
 .multiselect__accordion-toggle{
   z-index: 5;
   display: flex;
@@ -907,6 +911,7 @@ fieldset[disabled] .multiselect {
   border-width: 5px 5px 0;
   content: "";
   color: #999;
+  transition: transform .2s ease;
 }
 
 .multiselect__accordion-toggle:hover{

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -366,6 +366,29 @@ export default {
 
       return options.slice(0, this.optionsLimit)
     },
+    filteredCollapsibleOptions () {
+      let options = this.filteredOptions
+      let groupedOptions = {}
+      let ungroupedOptions = []
+      let currentGroup = null
+
+      if (options.length) {
+        options.forEach(v => {
+          if (v['$isLabel']) {
+            currentGroup = v['$groupLabel']
+            groupedOptions[`${v['$groupLabel']}`] = []
+          } else if (currentGroup) {
+            groupedOptions[currentGroup].push(v)
+          } else{
+            ungroupedOptions.push(v)
+          }
+        })
+      }
+
+      if (ungroupedOptions.length) groupedOptions['Uncategorized'] = ungroupedOptions
+
+      return groupedOptions
+    },
     valueKeys () {
       if (this.trackBy) {
         return this.internalValue.map(element => element[this.trackBy])
@@ -543,10 +566,12 @@ export default {
      * If all group optiona are already selected -> remove it from the results.
      *
      * @param  {Object||String||Integer} group to select/deselect
+     * @param {Booelan} collapsible use selection logic to check nested elements
      */
-    selectGroup (selectedGroup) {
+    selectGroup (selectedGroup, collapsible = false) {
       const group = this.options.find(option => {
-        return option[this.groupLabel] === selectedGroup.$groupLabel
+        let comparisonString = collapsible ? selectedGroup : selectedGroup.$groupLabel
+        return option[this.groupLabel] === comparisonString
       })
 
       if (!group) return

--- a/src/pointerMixin.js
+++ b/src/pointerMixin.js
@@ -46,7 +46,7 @@ export default {
         'multiselect__option--selected': this.isSelected(option)
       }
     },
-    groupHighlight (index, selectedGroup, collapsible = false) {
+    groupHighlight (index, selectedGroup, collapsible = false, open = false) {
       if (!this.groupSelect) {
         return ['multiselect__option--group', 'multiselect__option--disabled']
       }
@@ -59,7 +59,8 @@ export default {
       return group && !this.wholeGroupDisabled(group) ? [
         'multiselect__option--group',
         { 'multiselect__option--highlight': index === this.pointer && this.showPointer },
-        { 'multiselect__option--group-selected': this.wholeGroupSelected(group) }
+        { 'multiselect__option--group-selected': this.wholeGroupSelected(group) },
+        { 'open': open }
       ] : 'multiselect__option--disabled'
     },
     addPointerElement ({ key } = 'Enter') {

--- a/src/pointerMixin.js
+++ b/src/pointerMixin.js
@@ -46,13 +46,14 @@ export default {
         'multiselect__option--selected': this.isSelected(option)
       }
     },
-    groupHighlight (index, selectedGroup) {
+    groupHighlight (index, selectedGroup, collapsible = false) {
       if (!this.groupSelect) {
         return ['multiselect__option--group', 'multiselect__option--disabled']
       }
 
       const group = this.options.find(option => {
-        return option[this.groupLabel] === selectedGroup.$groupLabel
+        let comparisonString = collapsible ? selectedGroup : selectedGroup.$groupLabel
+        return option[this.groupLabel] === comparisonString
       })
 
       return group && !this.wholeGroupDisabled(group) ? [


### PR DESCRIPTION
Added an option to create collapsible accordion style lists from grouped content.

Custom `HeightTransition` component added to animate accordion height when collapsing or expanding. 

![image](https://user-images.githubusercontent.com/54451869/75711611-b16f5480-5c94-11ea-847d-c206256b393c.png)

Prop `collapseGroups` implemented for grouped content to add this feature

![image](https://user-images.githubusercontent.com/54451869/75711719-dc59a880-5c94-11ea-8db6-e5ef906a5134.png)

![Accordion Collapse Hover](https://user-images.githubusercontent.com/54451869/75711760-ebd8f180-5c94-11ea-9de8-2487787b0b00.PNG)

![Accordion Collapsed](https://user-images.githubusercontent.com/54451869/75711773-ef6c7880-5c94-11ea-8fa9-da548bc2e0f3.PNG)

This feature also supports groups that have group selection elements disabled

![Accordion Collapse Disabled Hover](https://user-images.githubusercontent.com/54451869/75711861-12972800-5c95-11ea-9a0c-ee7b803d79b3.PNG)