### PR TITLE
ReferenceError fixed

### DIFF
--- a/src/pointerMixin.js
+++ b/src/pointerMixin.js
@@ -36,7 +36,7 @@ export default {
       this.pointerDirty = false
     },
     pointer () {
-      this.$refs.search.setAttribute('aria-activedescendant', this.id + '-' + this.pointer.toString())
+      this.$refs.search && this.$refs.search.setAttribute('aria-activedescendant', this.id + '-' + this.pointer.toString())
     }
   },
   methods: {


### PR DESCRIPTION
If multiselect is not searchable, then pointing at selects will throw an error.