### PR TITLE
Fix internalValue to filter null and undefind

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -333,7 +333,7 @@ export default {
   computed: {
     internalValue () {
       return this.value || this.value === 0
-        ? Array.isArray(this.value) ? this.value : [this.value]
+        ? Array.isArray(this.value) ? this.value.filter(option => ![null, undefined].includes(option)) : [this.value]
         : []
     },
     filteredOptions () {


### PR DESCRIPTION
### Fix internalValue computed to filter null and undefind.

The problem was that, in multiple mode, if we give the value prop an array that includes null or undefinded, then we have an error(Cannot read property 'id' of null).