### PR TITLE
fix options with isTag field

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -115,7 +115,7 @@
                   :class="optionHighlight(index, option)"
                   @click.stop="select(option)"
                   @mouseenter.self="pointerSet(index)"
-                  :data-select="option && option.isTag ? tagPlaceholder : selectLabelText"
+                  :data-select="option && taggable && option.isTag ? tagPlaceholder : selectLabelText"
                   :data-selected="selectedLabelText"
                   :data-deselect="deselectLabelText"
                   class="multiselect__option">

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -480,7 +480,7 @@ export default {
     getOptionLabel (option) {
       if (isEmpty(option)) return ''
       /* istanbul ignore else */
-      if (option.isTag) return option.label
+      if (this.taggable && option.isTag) return option.label
       /* istanbul ignore else */
       if (option.$isLabel) return option.$groupLabel
 
@@ -512,7 +512,7 @@ export default {
       if (this.max && this.multiple && this.internalValue.length === this.max) return
       /* istanbul ignore else */
       if (key === 'Tab' && !this.pointerDirty) return
-      if (option.isTag) {
+      if (this.taggable && option.isTag) {
         this.$emit('tag', option.label, this.id)
         this.search = ''
         if (this.closeOnSelect && !this.multiple) this.deactivate()


### PR DESCRIPTION
###  options with isTag

If for any reason, `options` given as prop includes records with `isTag` property (in our project, we used isTag property for another purpose), but `taggable` prop was not provided or set to false, those records are considered as tag which we don't want that.

It's better that before checking if an option has `isTag` field, we check if taggable prop is `true`.