### PR TITLE
Explicitly check type of search

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -659,7 +659,7 @@ export default {
         if (!this.preserveSearch) this.search = ''
         this.$nextTick(() => { if (typeof this.$refs.search !== 'undefined') this.$refs.search.focus() })
       } else {
-        this.$el.focus()
+        if (typeof this.$el !== 'undefined') this.$el.focus()
       }
       this.$emit('open', this.id)
     },

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -657,7 +657,7 @@ export default {
       /* istanbul ignore else  */
       if (this.searchable) {
         if (!this.preserveSearch) this.search = ''
-        this.$nextTick(() => this.$refs.search && this.$refs.search.focus())
+        this.$nextTick(() => { if (typeof this.$refs.search !== 'undefined') this.$refs.search.focus() })
       } else {
         this.$el.focus()
       }
@@ -674,9 +674,9 @@ export default {
       this.isOpen = false
       /* istanbul ignore else  */
       if (this.searchable) {
-        this.$refs.search && this.$refs.search.blur()
+        if (typeof this.$refs.search !== 'undefined') this.$refs.search.blur()
       } else {
-        this.$el.blur()
+        if (typeof this.$el !== 'undefined') this.$el.blur()
       }
       if (!this.preserveSearch) this.search = ''
       this.$emit('close', this.getValue(), this.id)


### PR DESCRIPTION
This is an attempt to fix https://github.com/shentao/vue-multiselect/issues/1421

It seems that current ln 677 of multiselectMixin.js  
```js
      if (this.searchable) {
        this.$refs.search && this.$refs.search.blur()
      } else {
        this.$el.blur()
      }
```
ends up compiling to 

`this.searchable?this.$refs.search.blur():this.$el.blur()` 

Changing this to 
```js
      if (this.searchable) {
        this.$refs.search?.blur()
      } else {
        this.$el.blur()
      }
```