### PR TITLE
Stop mousedown event propogation when calling toggle

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -72,7 +72,7 @@
       <span
         v-if="isSingleLabelVisible"
         class="multiselect__single"
-        @mousedown.prevent="toggle"
+        @mousedown.prevent.stop="toggle"
       >
         <slot name="singleLabel" :option="singleValue">
           {{ currentOptionLabel }}
@@ -81,7 +81,7 @@
       <span
         v-if="isPlaceholderVisible"
         class="multiselect__placeholder"
-        @mousedown.prevent="toggle"
+        @mousedown.prevent.stop="toggle"
       >
         <slot name="placeholder">
           {{ placeholder }}


### PR DESCRIPTION
Mousedown event propagation is not stopped in all cases: only currently when you click the "caret" icon. This makes all mousedown events also stop propogation.

This was found to cause strange behavior in cases where other components were also listening for mousedown events. For example, the [Vue Headless UI Dialog](https://headlessui.dev/vue/dialog) from Tailwind also [uses a mousedown event](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-vue/src/components/dialog/dialog.ts#L196-L205), and not stopping propagation was causing the modal to close any time the multiselect component was clicked without `.stop` on the mousedown event.

I didn't include a reproduction link because the [caret already has `.stop` on the propagation](https://github.com/shentao/vue-multiselect/blob/master/src/Multiselect.vue#L15) and this makes it consistent, but please let me know if you would like one.