### PR TITLE
fix(1687): Force Vue Compat to use component as Vue 3

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -163,7 +163,8 @@ export default {
   name: 'vue-multiselect',
   mixins: [multiselectMixin, pointerMixin],
   compatConfig: {
-    MODE: 3
+    MODE: 3,
+    ATTR_ENUMERATED_COERCION: false
   },
   props: {
     /**

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -162,6 +162,9 @@ import pointerMixin from './pointerMixin'
 export default {
   name: 'vue-multiselect',
   mixins: [multiselectMixin, pointerMixin],
+  compatConfig: {
+    MODE: 3
+  },
   props: {
     /**
        * name attribute to match optional label element


### PR DESCRIPTION
Fixes #1687, #1677

When Compat mode is used, we tell Vue Compat is treat our component as fully Vue 3 ready
