### PR TITLE
fix(1636)-list-not-empty

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -143,7 +143,7 @@
               <slot name="noResult" :search="search">No elements found. Consider changing the search query.</slot>
             </span>
           </li>
-            <li v-show="showNoOptions && ((options.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)">
+            <li v-show="showNoOptions && ((filteredOptions.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)">
             <span class="multiselect__option">
               <slot name="noOptions">List is empty.</slot>
             </span>


### PR DESCRIPTION
Now by default list is empty will be show on selecting all the options from the list

This is a new pull request (Closed PR #1699 ) after rebasing to next from master. 

Closes Issue #1636 
