### PR TITLE
Spellcheck fix for Vue3

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -52,7 +52,7 @@
         :id="id"
         type="text"
         autocomplete="off"
-        spellcheck="false"
+        :spellcheck="false"
         :placeholder="placeholder"
         :style="inputStyle"
         :value="search"


### PR DESCRIPTION
Even with the compat configuration,  the library is still warning about the `ATTR_ENUMERATED_COERCION` flag. 

https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html