### PR TITLE
search-spellcheck: pass spellcheck as prop (Issue #991)

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -51,7 +51,7 @@
           :id="id"
           type="text"
           autocomplete="off"
-          spellcheck="false"
+          :spellcheck="spellcheck"
           :placeholder="placeholder"
           :style="inputStyle"
           :value="search"
@@ -269,6 +269,15 @@ export default {
      * @type {Boolean}
      */
     disabled: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Enables search input's spellcheck if true.
+     * @default false
+     * @type {Boolean}
+     */
+    spellcheck: {
       type: Boolean,
       default: false
     },


### PR DESCRIPTION
Pass the search field's spellcheck attribute as a prop with a default value of "false" as a fix for Issue #991 