### PR TITLE
fix: default group deselect

### DIFF
--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -563,8 +563,9 @@ export default {
       if (this.wholeGroupSelected(group)) {
         this.$emit('remove', group[this.groupValues], this.id)
 
+        const groupValues = this.trackBy ? group[this.groupValues].map(val => val[this.trackBy]) : group[this.groupValues]
         const newValue = this.internalValue.filter(
-          option => group[this.groupValues].indexOf(option) === -1
+          option => groupValues.indexOf(this.trackBy ? option[this.trackBy] : option) === -1
         )
 
         this.$emit('input', newValue, this.id)


### PR DESCRIPTION
Array's indexof property was not properly working for default selected groups. So, added filtering by trackBy values as well when we have the object options


Fixes #713 