### PR TITLE
Fix $isLabel issue

### DIFF
--- a/src/pointerMixin.js
+++ b/src/pointerMixin.js
@@ -129,6 +129,7 @@ export default {
       }
 
       if (this.filteredOptions.length > 0 &&
+        this.filteredOptions[this.pointer] &&  
         this.filteredOptions[this.pointer].$isLabel &&
         !this.groupSelect
       ) {


### PR DESCRIPTION
When `this.filteredOptions[this.pointer]` is null, it's breaking on `pointerAdjust`