### PR TITLE
Add aria-activedescendant attribute to component

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -10,7 +10,8 @@
     @keyup.esc="deactivate()"
     class="multiselect"
     role="combobox"
-    :aria-owns="'listbox-'+id">
+    :aria-owns="'listbox-'+id"
+    :aria-activedescendant="id + '-' + pointer">
     <slot name="caret" :toggle="toggle">
       <div @mousedown.prevent.stop="toggle()" class="multiselect__select"></div>
     </slot>

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -11,7 +11,7 @@
     class="multiselect"
     role="combobox"
     :aria-owns="'listbox-'+id"
-    :aria-activedescendant="id + '-' + pointer">
+    :aria-activedescendant="isOpen ? id + '-' + pointer : ''">
     <slot name="caret" :toggle="toggle">
       <div @mousedown.prevent.stop="toggle()" class="multiselect__select"></div>
     </slot>


### PR DESCRIPTION
This PR adds [`aria-activedescendant`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) to the main multiselect element to manage focus for assistive technologies such as screen readers. The attribute should be equal to the active option when the multiselect is open and blank when it is closed.
 
An example of the use of `aria-activedescendant` is available on the [ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/).

I haven't been able to build and test the PR as I haven't been able to install the npm packages as they seem to be quite outdated.