### PR TITLE
Update incorrect GettingStarted CDN instructions

### DIFF
--- a/documentation/src/GettingStarted.vue
+++ b/documentation/src/GettingStarted.vue
@@ -57,7 +57,7 @@
 </code></pre>
             <h3 class="typo__h3">via CDN</h3>
             <pre><code ref="cdn-usage">// register globally
-app.component('vue-multiselect', window.VueMultiselect.default)</code></pre>
+app.component('vue-multiselect', window['vue-multiselect'].default)</code></pre>
           </div>
         </div>
       </section>


### PR DESCRIPTION
I noticed through [this issue](https://github.com/shentao/vue-multiselect/issues/1756) that the documentation in the main page of the project is incorrect, since it mentions using `window.VueMultiselect`.

Afaik, the project moved from exposing itself from  `window.VueMultiselect` to `window['vue-multiselect']` when it transitioned to 3.X.