### PR TITLE
fix: mouseenter not firing on option content due to .self modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,21 @@ Thanks to Matt Elen for contributing this version!
 
 > A Vue 3 upgrade of [@shentao's](https://github.com/shentao) [vue-mulitselect](https://github.com/shentao/vue-multiselect) component. The idea is that when you upgrade to Vue 3, you can swap the two components out, and everything should simply work. Feel free to check out our story of how we upgraded our product to Vue 3 on our blog at  [suade.org](https://suade.org/a-products-vue-3-migration-a-real-life-story/)
 
+## Props
+
+### showNoOptions
+
+- Type: Boolean  
+- Default: true  
+
+Controls whether the "No options available" message is displayed when there are no options.
+
+Example:
+
+```html
+<VueMultiselect :showNoOptions="false" :options="[]" />
+```
+
 ## Contributing
 
 ``` bash

--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -122,7 +122,7 @@
                 v-if="!(option && (option.$isLabel || option.$isDisabled))"
                 :class="optionHighlight(index, option)"
                 @click.stop="select(option)"
-                @mouseenter.self="pointerSet(index)"
+                @mouseenter="pointerSet(index)"
                 :data-select="option && option.isTag ? tagPlaceholder : selectLabelText"
                 :data-selected="selectedLabelText"
                 :data-deselect="deselectLabelText"
@@ -136,7 +136,7 @@
                   :data-select="groupSelect && selectGroupLabelText"
                   :data-deselect="groupSelect && deselectGroupLabelText"
                   :class="groupHighlight(index, option)"
-                  @mouseenter.self="groupSelect && pointerSet(index)"
+                  @mouseenter="groupSelect && pointerSet(index)"
                   @mousedown.prevent="selectGroup(option)"
                   class="multiselect__option">
                 <slot name="option" :option="option" :search="search" :index="index">


### PR DESCRIPTION
Removes `.self` modifier from mouseenter events to ensure hover works correctly for slot content and nested elements.

This fixes cases where hovering over inner content (e.g., labels) does not trigger pointer updates.

Tested locally — hover works correctly for option text and grouped options.