### PR TITLE
fix(1939): openDirection not respected when useTeleport is enabled

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -96,7 +96,7 @@
       <transition name="multiselect">
         <div
           class="multiselect__content-wrapper"
-          :class="contentWrapperClass"
+          :class="[contentWrapperClass, { 'multiselect__content-wrapper--above': isAbove }]"
           v-if="isOpen && ready"
           @focus="activate"
           tabindex="-1"
@@ -460,20 +460,41 @@ export default {
           this.ready = false
           // This helps with the positioning of the open dropdown when teleport is being used
           this.$nextTick(() => {
-            const rect = this.$el.getBoundingClientRect()
-            this.dropdownStyles = {
-              position: 'absolute',
-              top: `${rect.bottom + window.scrollY}px`,
-              left: `${rect.left + window.scrollX}px`,
-              width: `${rect.width}px`,
-              zIndex: 9999
-            }
+            this.dropdownStyles = this.calculateDropdownStyles()
             this.ready = true
           })
         } else {
           this.ready = true
         }
       }
+    }
+  },
+  methods: {
+    /**
+     * Positions the teleported dropdown next to the multiselect, since the
+     * `.multiselect--above` CSS can no longer reach it once it's teleported.
+     *
+     * @return {Object} style object for the content wrapper
+     */
+    calculateDropdownStyles () {
+      const rect = this.$el.getBoundingClientRect()
+
+      const styles = {
+        position: 'absolute',
+        left: `${rect.left + window.scrollX}px`,
+        width: `${rect.width}px`,
+        zIndex: 9999
+      }
+
+      if (this.isAbove) {
+        // Shift up by its own height, so the list needn't be measured first
+        styles.top = `${rect.top + window.scrollY}px`
+        styles.transform = 'translateY(-100%)'
+      } else {
+        styles.top = `${rect.bottom + window.scrollY}px`
+      }
+
+      return styles
     }
   }
 }
@@ -771,14 +792,20 @@ export default {
     vertical-align: top;
   }
 
-  .multiselect--above .multiselect__content-wrapper {
-    bottom: 100%;
+  .multiselect--above .multiselect__content-wrapper,
+  .multiselect__content-wrapper--above {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     border-bottom: none;
     border-top: 1px solid #e8e8e8;
+  }
+
+  /* Not applied when teleported: combined with the inline `top` this would
+     stretch the dropdown instead of moving it up. */
+  .multiselect--above .multiselect__content-wrapper {
+    bottom: 100%;
   }
 
   .multiselect__content::-webkit-scrollbar {

--- a/src/multiselectMixin.js
+++ b/src/multiselectMixin.js
@@ -694,11 +694,13 @@ export default {
     adjustPosition () {
       if (typeof window === 'undefined') return
 
-      const spaceAbove = this.$el.getBoundingClientRect().top
-      const spaceBelow = window.innerHeight - this.$el.getBoundingClientRect().bottom
+      const rect = this.$el.getBoundingClientRect()
+      const spaceAbove = rect.top
+      const spaceBelow = window.innerHeight - rect.bottom
       const hasEnoughSpaceBelow = spaceBelow > this.maxHeight
+      const forcedAbove = this.openDirection === 'above' || this.openDirection === 'top'
 
-      if (hasEnoughSpaceBelow || spaceBelow > spaceAbove || this.openDirection === 'below' || this.openDirection === 'bottom') {
+      if (!forcedAbove && (hasEnoughSpaceBelow || spaceBelow > spaceAbove || this.openDirection === 'below' || this.openDirection === 'bottom')) {
         this.preferredOpenDirection = 'below'
         this.optimizedHeight = Math.min(spaceBelow - 40, this.maxHeight)
       } else {

--- a/tests/unit/Multiselect.spec.js
+++ b/tests/unit/Multiselect.spec.js
@@ -810,7 +810,7 @@ describe('Multiselect.vue', () => {
       wrapper.vm.pointerAdjust()
       expect(wrapper.vm.pointer).toBe(2)
     })
-    test('should adjust the pointer to the first non-group-label option after changed from empty', async () => {
+    test('should adjust the pointer to the first non-group-label option after changed from empty', () => {
       const wrapper = shallowMount(Multiselect, {
         props: {
           modelValue: [],
@@ -827,7 +827,7 @@ describe('Multiselect.vue', () => {
         { group: [{ id: '1' }, { id: '2' }], groupLabel: 'A' }
       ]
       setTimeout(function () {
-      expect(wrapper.vm.pointer).toBe(1)
+        expect(wrapper.vm.pointer).toBe(1)
       }, 0)
     })
   })

--- a/tests/unit/Multiselect.spec.js
+++ b/tests/unit/Multiselect.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import Multiselect from '@/Multiselect.vue'
 
 describe('Multiselect.vue', () => {
@@ -810,7 +810,7 @@ describe('Multiselect.vue', () => {
       wrapper.vm.pointerAdjust()
       expect(wrapper.vm.pointer).toBe(2)
     })
-    test('should adjust the pointer to the first non-group-label option after changed from empty', () => {
+    test('should adjust the pointer to the first non-group-label option after changed from empty', async () => {
       const wrapper = shallowMount(Multiselect, {
         props: {
           modelValue: [],
@@ -827,7 +827,7 @@ describe('Multiselect.vue', () => {
         { group: [{ id: '1' }, { id: '2' }], groupLabel: 'A' }
       ]
       setTimeout(function () {
-        expect(wrapper.vm.pointer).toBe(1)
+      expect(wrapper.vm.pointer).toBe(1)
       }, 0)
     })
   })
@@ -1877,6 +1877,143 @@ describe('Multiselect.vue', () => {
       expect(wrapper.vm.filteredOptions[0].name).toBe('Rails')
       expect(wrapper.vm.filteredOptions[1].name).toBe('Vue.js')
       expect(wrapper.vm.filteredOptions[2].name).toBe('Laravel')
+    })
+  })
+
+  describe('openDirection', () => {
+    const stubRect = (wrapper, rect) => {
+      wrapper.vm.$el.getBoundingClientRect = () => ({
+        top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, ...rect
+      })
+    }
+
+    const mountAt = (rect, props = {}) => {
+      window.innerHeight = 800
+      const wrapper = shallowMount(Multiselect, {
+        props: { modelValue: [], options: ['1', '2', '3'], ...props }
+      })
+      stubRect(wrapper, rect)
+      return wrapper
+    }
+
+    afterEach(() => {
+      window.scrollY = 0
+      window.scrollX = 0
+    })
+
+    describe('adjustPosition', () => {
+      test('should open below and size to the space below when it fits', () => {
+        const wrapper = mountAt({ top: 20, bottom: 60 })
+
+        wrapper.vm.adjustPosition()
+
+        expect(wrapper.vm.isAbove).toBe(false)
+        expect(wrapper.vm.optimizedHeight).toBe(300)
+      })
+
+      test('should open above and size to the space above when there is no room below', () => {
+        const wrapper = mountAt({ top: 700, bottom: 740 })
+
+        wrapper.vm.adjustPosition()
+
+        expect(wrapper.vm.isAbove).toBe(true)
+        expect(wrapper.vm.optimizedHeight).toBe(300)
+      })
+
+      test('should size to the space above when opening above is forced', () => {
+        const wrapper = mountAt({ top: 100, bottom: 140 }, { openDirection: 'above' })
+
+        wrapper.vm.adjustPosition()
+
+        expect(wrapper.vm.isAbove).toBe(true)
+        // 100px above - 40px offset, instead of the 660px available below
+        expect(wrapper.vm.optimizedHeight).toBe(60)
+      })
+    })
+
+    describe(':useTeleport', () => {
+      test('should position the teleported dropdown below the multiselect', () => {
+        const wrapper = mountAt({ top: 20, bottom: 60, left: 15, width: 200 }, { useTeleport: true })
+
+        wrapper.vm.adjustPosition()
+
+        expect(wrapper.vm.calculateDropdownStyles()).toEqual({
+          position: 'absolute',
+          top: '60px',
+          left: '15px',
+          width: '200px',
+          zIndex: 9999
+        })
+      })
+
+      test('should position the teleported dropdown above the multiselect', () => {
+        const wrapper = mountAt({ top: 700, bottom: 740, left: 15, width: 200 }, { useTeleport: true })
+
+        wrapper.vm.adjustPosition()
+
+        expect(wrapper.vm.calculateDropdownStyles()).toEqual({
+          position: 'absolute',
+          top: '700px',
+          transform: 'translateY(-100%)',
+          left: '15px',
+          width: '200px',
+          zIndex: 9999
+        })
+      })
+
+      test('should honour a forced openDirection when positioning the teleported dropdown', () => {
+        const wrapper = mountAt({ top: 100, bottom: 140, left: 15, width: 200 }, {
+          useTeleport: true,
+          openDirection: 'above'
+        })
+
+        wrapper.vm.adjustPosition()
+        const styles = wrapper.vm.calculateDropdownStyles()
+
+        expect(styles.top).toBe('100px')
+        expect(styles.transform).toBe('translateY(-100%)')
+      })
+
+      test('should take the document scroll position into account', () => {
+        const wrapper = mountAt({ top: 700, bottom: 740, left: 15, width: 200 }, { useTeleport: true })
+        window.scrollY = 500
+        window.scrollX = 10
+
+        wrapper.vm.adjustPosition()
+        const styles = wrapper.vm.calculateDropdownStyles()
+
+        expect(styles.top).toBe('1200px')
+        expect(styles.left).toBe('25px')
+      })
+
+      test('should apply the position and the above marker when the dropdown opens', async () => {
+        window.innerHeight = 800
+        // mount() instead of shallowMount(), which stubs out the teleport itself
+        const wrapper = mount(Multiselect, {
+          props: {
+            modelValue: [],
+            options: ['1', '2', '3'],
+            useTeleport: true,
+            id: 'teleported'
+          }
+        })
+        stubRect(wrapper, { top: 700, bottom: 740, left: 15, width: 200 })
+
+        wrapper.vm.activate()
+        // The isOpen watcher defers measuring to $nextTick, so let the queue drain
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        // Scoped through the id, so lingering dropdowns from other tests can't match
+        const dropdown = document.body
+          .querySelector('#listbox-teleported')
+          .closest('.multiselect__content-wrapper')
+
+        expect(dropdown.classList.contains('multiselect__content-wrapper--above')).toBe(true)
+        expect(dropdown.style.top).toBe('700px')
+        expect(dropdown.style.transform).toBe('translateY(-100%)')
+
+        wrapper.unmount()
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes #1939

## Problem

With `useTeleport` enabled the dropdown always opens downwards. When there is
no room below the multiselect the list is clipped by the viewport instead of
flipping above the control, and setting `openDirection="above"` explicitly has
no effect either.

## Root cause

Opening upwards was never implemented in JS — it relied entirely on CSS:

```css
.multiselect--above .multiselect__content-wrapper {
  bottom: 100%;
  /* + flipped borders and radii */
}
```

`multiselect--above` is bound on the root element, and the wrapper resolves
`bottom: 100%` against its `position: relative`. Once teleported, the wrapper is
no longer a descendant of the root, so this descendant selector never matches —
which loses both the positioning *and* the flipped borders.

The inline styles applied when teleporting then hardcoded a downward anchor,
ignoring `isAbove` entirely:

```js
top: `${rect.bottom + window.scrollY}px`
```

`isAbove` was computed correctly all along — it just had no effect on anything.

## Changes

- **Position the teleported dropdown according to `isAbove`.** When above, anchor
  `top` to `rect.top` and apply `transform: translateY(-100%)`. The transform
  avoids having to measure the rendered list, whose height isn't known at that
  point because the content can be shorter than `optimizedHeight` — and it avoids
  an extra render tick and the flash that comes with it.

- **Add `multiselect__content-wrapper--above` on the wrapper itself**, so the
  flipped borders and radii survive teleporting. `bottom: 100%` stays scoped to
  the non-teleported selector: combined with the inline `top`, it would stretch
  the absolutely positioned dropdown between both edges instead of moving it up.
  The class doubles as a styling hook for the teleported element, alongside
  `contentWrapperClass`.

- **`adjustPosition()` now respects a forced `openDirection` of `above`/`top`**
  when computing `optimizedHeight`. It previously fell through to the `below`
  branch whenever there was room below, sizing the dropdown to the space *below*
  the control while rendering it *above*. This was masked as long as teleported
  dropdowns never opened upwards at all.

Behaviour is unchanged when `useTeleport` is false — that path still positions
through CSS.

## Testing

Adds 8 tests covering `adjustPosition` direction and sizing, and the teleported
positioning including scroll offsets and the rendered DOM output. Full suite
113/113 passing, lint clean.

Note for reviewers: `shallowMount` stubs out `<teleport>` (renders an empty
`<teleport-stub>`), so the DOM-level assertion uses `mount`.

## Not related to this issue

Also repairs a pre-existing broken test in `#pointerAdjust()`. It assigned
`wrapper.vm.source` instead of the `options` prop, so `filteredOptions` never
changed and `pointerAdjust()` was never triggered, and its assertion sat in a
`setTimeout` without `done`/`await` — so it ran after the test had already
finished and failed outside of any test. The new tests introduce a macrotask
tick, which surfaced it. Happy to split this into its own commit if preferred.
